### PR TITLE
👔 Cardクラスのランクの算出をゲームによって変更できるようにした

### DIFF
--- a/src/models/blackjack/BlackjackRankStrategy.ts
+++ b/src/models/blackjack/BlackjackRankStrategy.ts
@@ -1,18 +1,15 @@
 import { Rank } from '@/types/ranks'
 import { RankStrategy } from '@/models/common/RankStrategy'
+import rankValues from '@/models/blackjack/rankValues'
 
 export default class BlackjackRankStrategy implements RankStrategy {
+  // eslint-disable-next-line
   public getRankNumber(rank: Rank): number {
-    // eslint-disable-line
-    if (rank === 'Joker') {
-      return 0 // ジョーカーの場合は0とする（ブラックジャックでは使用されない）
+    const value: number | undefined = rankValues[rank]
+    if (value === undefined) {
+      throw new Error(`Invalid rank: ${rank}`)
     }
-    if (rank === 'A') {
-      return 1
-    }
-    if (rank === 'K' || rank === 'Q' || rank === 'J') {
-      return 10
-    }
-    return parseInt(rank, 10)
+
+    return value
   }
 }

--- a/src/models/blackjack/BlackjackRankStrategy.ts
+++ b/src/models/blackjack/BlackjackRankStrategy.ts
@@ -1,0 +1,18 @@
+import { Rank } from '@/types/ranks'
+import { RankStrategy } from '@/models/common/RankStrategy'
+
+export default class BlackjackRankStrategy implements RankStrategy {
+  public getRankNumber(rank: Rank): number {
+    // eslint-disable-line
+    if (rank === 'Joker') {
+      return 0 // ジョーカーの場合は0とする（ブラックジャックでは使用されない）
+    }
+    if (rank === 'A') {
+      return 1
+    }
+    if (rank === 'K' || rank === 'Q' || rank === 'J') {
+      return 10
+    }
+    return parseInt(rank, 10)
+  }
+}

--- a/src/models/blackjack/rankValues.ts
+++ b/src/models/blackjack/rankValues.ts
@@ -1,0 +1,20 @@
+import { Rank } from '@/types/ranks'
+
+const rankValues: { [key in Rank]: number } = {
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+  '8': 8,
+  '9': 9,
+  '10': 10,
+  J: 10,
+  Q: 10,
+  K: 10,
+  A: 1,
+  Joker: 0
+}
+
+export default rankValues

--- a/src/models/common/Card.ts
+++ b/src/models/common/Card.ts
@@ -1,43 +1,50 @@
 import { Suit } from '@/types/suits'
 import { Rank } from '@/types/ranks'
+import { RankStrategy } from '@/models/common/RankStrategy'
 
 export default class Card {
   private suit?: Suit
 
   private rank: Rank
 
-  constructor(suit: Suit | undefined, rank: Rank) {
+  private rankStrategy: RankStrategy
+
+  constructor(suit: Suit | undefined, rank: Rank, rankStrategy: RankStrategy) {
     this.suit = suit
 
     this.rank = rank
+
+    this.rankStrategy = rankStrategy
   }
 
-  // ファクトリメソッドを使ったジョーカーインスタンスの作成
-  public static createJoker(): Card {
-    return new Card(undefined, 'Joker')
+  /**
+   * ファクトリメソッドを使用してジョーカーのカードインスタンスを作成します。
+   * ジョーカーは特殊なカードであり、通常のスートやランクを持ちません。
+   *
+   * @param rankStrategy - ランクを計算するための戦略
+   * @returns ジョーカーのカードインスタンス
+   */
+  public static createJoker(rankStrategy: RankStrategy): Card {
+    return new Card(undefined, 'Joker', rankStrategy)
   }
 
   public getSuit(): Suit | undefined {
     return this.suit
   }
 
-  // TODO: 必要ないかも
   public getRank(): Rank {
     return this.rank
   }
 
-  // TODO: 後で実装する ゲームごとに違う 今はブラックジャック用
+  /**
+   * カードのランクを数値で取得します。
+   * このメソッドは、ストラテジーパターンを使用してランクを計算し、
+   * ゲームごとに異なるランクの計算ロジックを適用します。
+   *
+   * @returns カードのランクに対応する数値
+   */
   public getRankNumber(): number {
-    if (this.rank === 'Joker') {
-      return 0 // ジョーカーの場合は0とする（ブラックジャックでは使用されない）
-    }
-    if (this.rank === 'A') {
-      return 1
-    }
-    if (this.rank === 'K' || this.rank === 'Q' || this.rank === 'J') {
-      return 10
-    }
-    return parseInt(this.rank, 10)
+    return this.rankStrategy.getRankNumber(this.rank)
   }
 
   public toString(): string {

--- a/src/models/common/RankStrategy.ts
+++ b/src/models/common/RankStrategy.ts
@@ -1,0 +1,5 @@
+import { Rank } from '@/types/ranks'
+
+export interface RankStrategy {
+  getRankNumber(rank: Rank): number
+}

--- a/src/models/poker/PokerRankStrategy.ts
+++ b/src/models/poker/PokerRankStrategy.ts
@@ -1,0 +1,31 @@
+import { Rank } from '@/types/ranks'
+import { RankStrategy } from '@/models/common/RankStrategy'
+
+export default class PokerRankStrategy implements RankStrategy {
+  public getRankNumber(rank: Rank): number {
+    // eslint-disable-line
+    const rankValues: { [key in Rank]: number } = {
+      '2': 2,
+      '3': 3,
+      '4': 4,
+      '5': 5,
+      '6': 6,
+      '7': 7,
+      '8': 8,
+      '9': 9,
+      '10': 10,
+      J: 11,
+      Q: 12,
+      K: 13,
+      A: 14,
+      Joker: 0
+    }
+
+    const value: number = rankValues[rank]
+    if (!rank) {
+      throw new Error(`Invalid rank: ${rank}`)
+    }
+
+    return value
+  }
+}

--- a/src/models/poker/PokerRankStrategy.ts
+++ b/src/models/poker/PokerRankStrategy.ts
@@ -1,28 +1,12 @@
 import { Rank } from '@/types/ranks'
 import { RankStrategy } from '@/models/common/RankStrategy'
+import rankValues from '@/models/poker/rankValues'
 
 export default class PokerRankStrategy implements RankStrategy {
+  // eslint-disable-next-line
   public getRankNumber(rank: Rank): number {
-    // eslint-disable-line
-    const rankValues: { [key in Rank]: number } = {
-      '2': 2,
-      '3': 3,
-      '4': 4,
-      '5': 5,
-      '6': 6,
-      '7': 7,
-      '8': 8,
-      '9': 9,
-      '10': 10,
-      J: 11,
-      Q: 12,
-      K: 13,
-      A: 14,
-      Joker: 0
-    }
-
-    const value: number = rankValues[rank]
-    if (!rank) {
+    const value: number | undefined = rankValues[rank]
+    if (value === undefined) {
       throw new Error(`Invalid rank: ${rank}`)
     }
 

--- a/src/models/poker/rankValues.ts
+++ b/src/models/poker/rankValues.ts
@@ -1,0 +1,20 @@
+import { Rank } from '@/types/ranks'
+
+const rankValues: { [key in Rank]: number } = {
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+  '8': 8,
+  '9': 9,
+  '10': 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+  A: 14,
+  Joker: 0
+}
+
+export default rankValues


### PR DESCRIPTION
CardクラスのgetRankNumberメソッドの処理内容をゲームごとに切り替えるようにした。
カードインスタンスを作成するときにゲームを指定するという使い方です。